### PR TITLE
Overwritten property

### DIFF
--- a/public/javascripts/effects.js
+++ b/public/javascripts/effects.js
@@ -718,7 +718,6 @@ Effect.SlideUp = function(element) {
   return new Effect.Scale(element, window.opera ? 0 : 1,
    Object.extend({ scaleContent: false,
     scaleX: false,
-    scaleMode: 'box',
     scaleFrom: 100,
     scaleMode: {originalHeight: elementDimensions.height, originalWidth: elementDimensions.width},
     restoreAfterFinish: true,


### PR DESCRIPTION
If an object literal has two properties with the same name, the second property overwrites the first one, which makes the code hard to understand and error-prone.

In ECMAScript 2015 and above, as well as ECMAScript 5 non-strict mode, an object literal may define the same property multiple times, with later definitions overwriting earlier ones. In particular, if the last definition assigns a different value from earlier definitions, the earlier value is lost, which is most likely unintentional and should be avoided.

